### PR TITLE
Add support for release notes in the App Center step.

### DIFF
--- a/lib/highway/steps/library/appcenter.rb
+++ b/lib/highway/steps/library/appcenter.rb
@@ -10,9 +10,9 @@ require "highway/steps/infrastructure"
 module Highway
     module Steps
       module Library
-  
+
         class AppCenterStep < Step
-  
+
           def self.name
             "appcenter"
           end
@@ -20,7 +20,7 @@ module Highway
           def self.plugin_name
             "fastlane-plugin-appcenter"
           end
-  
+
           def self.parameters
             [
               Parameters::Single.new(
@@ -60,12 +60,18 @@ module Highway
                 required: false,
                 type: Types::Bool.new(),
                 default: false
+              ),
+              Parameters::Single.new(
+                name: "release_notes",
+                required: false,
+                type: Types::String.new(),
+                default: ""
               )
             ]
           end
-  
+
           def self.run(parameters:, context:, report:)
-  
+
             app_name = parameters["app_name"]
             api_token = parameters["api_token"]
             destinations = parameters["distribution_group"]
@@ -73,9 +79,10 @@ module Highway
             notify = parameters["notify"]
             owner_name = parameters["owner_name"]
             upload_dsym_only = parameters["upload_dsym_only"]
+            release_notes = parameters["release_notes"]
 
             context.assert_gem_available!(plugin_name)
-  
+
             context.run_action("appcenter_upload", options: {
               api_token: api_token,
               owner_name: owner_name,
@@ -83,34 +90,35 @@ module Highway
               destinations: destinations,
               notify_testers: notify,
               dsym: dsym,
-              upload_dsym_only: upload_dsym_only
+              upload_dsym_only: upload_dsym_only,
+              release_notes: release_notes
             })
-  
+
             response = context.fastlane_lane_context[:APPCENTER_BUILD_INFORMATION]
 
             unless response.nil?
               report[:deployment] = {
-  
+
                 service: "AppCenter",
-    
+
                 package: {
                   name: response["app_display_name"],
                   version: response["short_version"],
                   build: response["version"],
                 },
-    
+
                 urls: {
                   install: response["install_url"],
                   view: response["download_url"],
                 },
-    
+
               }
             end
-  
+
           end
-  
+
         end
-  
+
       end
     end
   end

--- a/spec/highway/steps/library/appcenter_spec.rb
+++ b/spec/highway/steps/library/appcenter_spec.rb
@@ -10,7 +10,7 @@ require "spec/helpers/context_mock"
 describe Highway::Steps::Library::AppCenterStep do
     before {
         @context = HighwaySpec::Helpers::ContextMock.new()
-        @context.fastlane_lane_context = { 
+        @context.fastlane_lane_context = {
             :APPCENTER_BUILD_INFORMATION => {
                 "app_display_name" => "AppTest",
                 "short_version" => "1.1.0",
@@ -31,7 +31,8 @@ describe Highway::Steps::Library::AppCenterStep do
             "app_name" => "AppTest",
             "api_token" => "12345abcde",
             "distribution_group" => "Testers",
-            "owner_name" => "owner"
+            "owner_name" => "owner",
+            "release_notes" => "Fixture release notes."
         }
 
         Highway::Steps::Library::AppCenterStep.run(parameters: parameters, context: @context, report: @report)
@@ -40,5 +41,6 @@ describe Highway::Steps::Library::AppCenterStep do
         expect(@context.run_action_options[:owner_name]).to eq(parameters["owner_name"])
         expect(@context.run_action_options[:app_name]).to eq(parameters["app_name"])
         expect(@context.run_action_options[:destinations]).to eq(parameters["distribution_group"])
+        expect(@context.run_action_options[:release_notes]).to eq(parameters["release_notes"])
     end
 end


### PR DESCRIPTION
This PR contains a code that allows to set App Center release notes via highwayfile.yml.

I don't know whether it's a big deal or not by my editor removed all empty spaces within edited files. If they're somehow necessary feel free to request a change.

@anyashka - Big thanks to for the inspiration.