### PR TITLE
[Fix] Couldn't parse the number of tests from the output.

### DIFF
--- a/lib/highway/steps/library/xcode_test.rb
+++ b/lib/highway/steps/library/xcode_test.rb
@@ -111,6 +111,7 @@ module Highway
           output_dir = context.artifacts_dir
           output_types = ["html", "junit"].join(",")
           output_files = [output_html_file, output_junit_file].join(",")
+          xcodebuild_formatter = "xcpretty"
 
           # Prepare temporary variables.
 
@@ -139,6 +140,7 @@ module Highway
               output_directory: output_dir,
               output_types: output_types,
               output_files: output_files,
+              xcodebuild_formatter: xcodebuild_formatter,
 
             })
 


### PR DESCRIPTION
### The problem
<img width="1300" alt="Zrzut ekranu 2022-07-4 o 11 17 04" src="https://user-images.githubusercontent.com/1449108/177124310-b0d910e5-2e2a-45ec-8b4a-8d0521a6a128.png">
fastlane is now supporting different xcodebuild formatters and favorises `xcbeautify` over `xcpretty`. If `xcbeautify` is installed, it will use it.  This is causing the problem we are seeing. `Couldn't parse the number of tests from the output.` 

### Solution
Explicitly set `xcpretty` as formatter