### PR TITLE
1.06 Release. Bug fix. Update highway.gemspec

### DIFF
--- a/highway.gemspec
+++ b/highway.gemspec
@@ -36,5 +36,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.5.0"
   spec.add_development_dependency "simplecov", "~> 0.17.0"
-  
 end

--- a/highway.gemspec
+++ b/highway.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.5.0"
   spec.add_development_dependency "simplecov", "~> 0.17.0"
+  
 end

--- a/highway.gemspec
+++ b/highway.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   # Dependencies
 
-  spec.add_dependency "fastlane", ">= 2.0.0", "<= 3.0.0"
+  spec.add_dependency "fastlane", ">= 2.201.0", "<= 3.0.0"
   spec.add_dependency "slack-notifier", ">= 2.0.0", "<= 3.0.0"
   spec.add_dependency "uri-ssh_git", ">= 2.0.0", "<= 3.0.0"
   spec.add_dependency "xcpretty-json-formatter", ">= 0.1.1", "<= 1.0.0"


### PR DESCRIPTION
Now the Highway requires the `2.201.0` version of Fastlane. Before the step `xcode_test` was failing regarding not supported `xcodebuild_formatter` parameter