### PR TITLE
Allow custom fastlane params for xcode_test step

### DIFF
--- a/lib/highway/steps/library/xcode_test.rb
+++ b/lib/highway/steps/library/xcode_test.rb
@@ -68,7 +68,12 @@ module Highway
               name: "code_coverage",
               type: Types::Bool.new(),
               required: false,
-            )
+            ),
+            Parameters::Single.new(
+              name: "fastlane_params",
+              type: Types::Hash.new(Types::Any.new()),
+              required: false
+            ),
           ]
         end
 
@@ -83,6 +88,7 @@ module Highway
           scheme = parameters["scheme"]
           skip_build = parameters["skip_build"]
           code_coverage = parameters["code_coverage"]
+          fastlane_params = parameters["fastlane_params"]
 
           flags = parameters["flags"].join(" ")
           settings = parameters["settings"].map { |setting, value| "#{setting}=\"#{value.shellescape}\"" }.join(" ")
@@ -120,29 +126,31 @@ module Highway
           rescued_error = nil
 
           # Run the build and test.
+          options = {
+
+            project_key => project_value,
+
+            clean: clean,
+            configuration: configuration,
+            device: device,
+            scheme: scheme,
+            code_coverage: code_coverage,
+            skip_build: skip_build,
+
+            xcargs: xcargs,
+
+            buildlog_path: output_raw_temp_dir,
+            output_directory: output_dir,
+            output_types: output_types,
+            output_files: output_files,
+            xcodebuild_formatter: xcodebuild_formatter,
+
+          }
 
           begin
-
-            context.run_action("run_tests", options: {
-
-              project_key => project_value,
-
-              clean: clean,
-              configuration: configuration,
-              device: device,
-              scheme: scheme,
-              code_coverage: code_coverage,
-              skip_build: skip_build,
-
-              xcargs: xcargs,
-
-              buildlog_path: output_raw_temp_dir,
-              output_directory: output_dir,
-              output_types: output_types,
-              output_files: output_files,
-              xcodebuild_formatter: xcodebuild_formatter,
-
-            })
+            fastlane_params = fastlane_params.nil? ? {} : fastlane_params
+            combined_options = fastlane_params.merge(options)
+            context.run_action("run_tests", options: combined_options)
 
           rescue FastlaneCore::Interface::FastlaneBuildFailure => error
 

--- a/lib/highway/version.rb
+++ b/lib/highway/version.rb
@@ -6,6 +6,6 @@
 module Highway
 
   # Version of Highway gem.
-  VERSION = "1.0.7".freeze
+  VERSION = "1.0.8".freeze
 
 end

--- a/spec/highway/steps/library/xcode_test_spec.rb
+++ b/spec/highway/steps/library/xcode_test_spec.rb
@@ -35,4 +35,37 @@ describe Highway::Steps::Library::XcodeTestStep do
         Highway::Steps::Library::XcodeTestStep.run(parameters: parameters, context: @context, report: @report)
         expect(@context.run_action_name).to eq("run_tests")
     end
+
+    it "Checks using fastlane_params" do
+        fastlane_params = {:extra_param1 => "fixture", :extra_param2 => 2}
+        parameters = {
+            "project" => { :tag => :project, :value => "Project.xcworkspace" },
+            "scheme" => "Release",
+            "flags" => [],
+            "clean" => true,
+            "settings" => {},
+            "fastlane_params" => fastlane_params
+        }
+
+        Highway::Steps::Library::XcodeTestStep.run(parameters: parameters, context: @context, report: @report)
+        expect(@context.run_action_name).to eq("run_tests")
+        expect(@context.run_action_options).to include(fastlane_params)
+    end 
+
+    it "Checks fastlane_params not overriding step params" do
+        fastlane_params = {:scheme => "fixture", :extra_param2 => 2}
+        parameters = {
+            "project" => { :tag => :project, :value => "Project.xcworkspace" },
+            "scheme" => "Release",
+            "flags" => [],
+            "clean" => true,
+            "settings" => {},
+            "fastlane_params" => fastlane_params
+        }
+
+        Highway::Steps::Library::XcodeTestStep.run(parameters: parameters, context: @context, report: @report)
+        expect(@context.run_action_name).to eq("run_tests")
+        expect(@context.run_action_options[:scheme]).to eq("Release")
+        expect(@context.run_action_options[:extra_param2]).to eq(2)
+    end 
 end


### PR DESCRIPTION
`xcode_test` step from highway is using `run_tests` action from fastlane under the hood. In particular cases it can be required that additional params available in `run_tests` fastlane step should be passed from highway `xcode_test` step as well. This PR allows such behaviour.
Use case:
```yml
- xcode_test:
    project: $(XCODEBUILD_PROJECT)
    scheme: $(XCODEBUILD_SCHEME)
    code_coverage: true
    skip_build: true
    device: "iPhone 13"
    settings:
        _BUILD_NUMBER: $(ENV:BITRISE_BUILD_NUMBER)
    fastlane_params:
        parallel_testing: true
        concurrent_workers: 5
```
Will add parameters from `fastlane_params` in `run_tests` execution.