### PR TITLE
Improve handling sh errors in xcode_test

### DIFF
--- a/lib/highway/runtime/context.rb
+++ b/lib/highway/runtime/context.rb
@@ -200,9 +200,9 @@ module Highway
       # @param bundle_exec [Boolean] Whether to use `bundle exec` if possible.
       # @param silent [Boolean] Whether to run the command silently.
       # @param on_error [Proc] Called if command exits with a non-zero code.
-      def run_sh(command, bundle_exec: false, silent: false, rescue_error: nil)
+      def run_sh(command, bundle_exec: false, silent: false, on_error: nil)
         command = ["bundle exec", command].flatten if bundle_exec && should_use_bundle_exec?
-        Fastlane::Actions.sh(command, log: !silent, error_callback: rescue_error)
+        Fastlane::Actions.sh(command, log: !silent, error_callback: on_error)
       end
 
       private

--- a/lib/highway/steps/library/xcode_test.rb
+++ b/lib/highway/steps/library/xcode_test.rb
@@ -193,7 +193,7 @@ module Highway
           # that happened in the build.
 
           error_callback = ->(error) { 
-            puts "callback eror: #{error}" 
+            rescued_error = error
           }
 
           xcpretty_json_formatter_path = context.run_sh("xcpretty-json-formatter", bundle_exec: true, silent: true, rescue_error: error_callback)

--- a/lib/highway/steps/library/xcode_test.rb
+++ b/lib/highway/steps/library/xcode_test.rb
@@ -196,11 +196,11 @@ module Highway
             rescued_error = error
           }
 
-          xcpretty_json_formatter_path = context.run_sh("xcpretty-json-formatter", bundle_exec: true, silent: true, rescue_error: error_callback)
+          xcpretty_json_formatter_path = context.run_sh("xcpretty-json-formatter", bundle_exec: true, silent: true, on_error: error_callback)
           temp_json_report_path = File.join(Dir.mktmpdir(), "report.json")
 
           context.with_modified_env({"XCPRETTY_JSON_FILE_OUTPUT" => temp_json_report_path}) do
-            context.run_sh(["cat", output_raw_path, "| xcpretty --formatter", xcpretty_json_formatter_path], bundle_exec: true, silent: true, rescue_error: error_callback)
+            context.run_sh(["cat", output_raw_path, "| xcpretty --formatter", xcpretty_json_formatter_path], bundle_exec: true, silent: true, on_error: error_callback)
           end
 
           # Export JSON file report to environment variable

--- a/lib/highway/steps/library/xcode_test.rb
+++ b/lib/highway/steps/library/xcode_test.rb
@@ -68,7 +68,12 @@ module Highway
               name: "code_coverage",
               type: Types::Bool.new(),
               required: false,
-            )
+            ),
+            Parameters::Single.new(
+              name: "fastlane_params",
+              type: Types::Hash.new(Types::Any.new()),
+              required: false
+            ),
           ]
         end
 
@@ -83,6 +88,7 @@ module Highway
           scheme = parameters["scheme"]
           skip_build = parameters["skip_build"]
           code_coverage = parameters["code_coverage"]
+          fastlane_params = parameters["fastlane_params"]
 
           flags = parameters["flags"].join(" ")
           settings = parameters["settings"].map { |setting, value| "#{setting}=\"#{value.shellescape}\"" }.join(" ")
@@ -120,29 +126,31 @@ module Highway
           rescued_error = nil
 
           # Run the build and test.
+          options = {
+
+            project_key => project_value,
+
+            clean: clean,
+            configuration: configuration,
+            device: device,
+            scheme: scheme,
+            code_coverage: code_coverage,
+            skip_build: skip_build,
+
+            xcargs: xcargs,
+
+            buildlog_path: output_raw_temp_dir,
+            output_directory: output_dir,
+            output_types: output_types,
+            output_files: output_files,
+            xcodebuild_formatter: xcodebuild_formatter,
+
+          }
 
           begin
-
-            context.run_action("run_tests", options: {
-
-              project_key => project_value,
-
-              clean: clean,
-              configuration: configuration,
-              device: device,
-              scheme: scheme,
-              code_coverage: code_coverage,
-              skip_build: skip_build,
-
-              xcargs: xcargs,
-
-              buildlog_path: output_raw_temp_dir,
-              output_directory: output_dir,
-              output_types: output_types,
-              output_files: output_files,
-              xcodebuild_formatter: xcodebuild_formatter,
-
-            })
+            fastlane_params = fastlane_params.nil? ? {} : fastlane_params
+            combined_options = fastlane_params.merge(options)
+            context.run_action("run_tests", options: combined_options)
 
           rescue FastlaneCore::Interface::FastlaneBuildFailure => error
 

--- a/lib/highway/steps/library/xcode_test.rb
+++ b/lib/highway/steps/library/xcode_test.rb
@@ -192,11 +192,15 @@ module Highway
           # That will output a machine-readable information about everything
           # that happened in the build.
 
-          xcpretty_json_formatter_path = context.run_sh("xcpretty-json-formatter", bundle_exec: true, silent: true)
+          error_callback = ->(error) { 
+            puts "callback eror: #{error}" 
+          }
+
+          xcpretty_json_formatter_path = context.run_sh("xcpretty-json-formatter", bundle_exec: true, silent: true, rescue_error: error_callback)
           temp_json_report_path = File.join(Dir.mktmpdir(), "report.json")
 
           context.with_modified_env({"XCPRETTY_JSON_FILE_OUTPUT" => temp_json_report_path}) do
-            context.run_sh(["cat", output_raw_path, "| xcpretty --formatter", xcpretty_json_formatter_path], bundle_exec: true, silent: true)
+            context.run_sh(["cat", output_raw_path, "| xcpretty --formatter", xcpretty_json_formatter_path], bundle_exec: true, silent: true, rescue_error: error_callback)
           end
 
           # Export JSON file report to environment variable

--- a/lib/highway/version.rb
+++ b/lib/highway/version.rb
@@ -6,6 +6,6 @@
 module Highway
 
   # Version of Highway gem.
-  VERSION = "1.0.7".freeze
+  VERSION = "1.0.8".freeze
 
 end

--- a/spec/helpers/context_mock.rb
+++ b/spec/helpers/context_mock.rb
@@ -32,7 +32,7 @@ module HighwaySpec
             def assert_gem_available!(name)
             end
 
-            def run_sh(command, bundle_exec: false, silent: false, rescue_error: nil)
+            def run_sh(command, bundle_exec: false, silent: false, on_error: nil)
                 command = ["bundle exec", command].flatten if bundle_exec && should_use_bundle_exec?
                 @run_sh_command = command
             end

--- a/spec/helpers/context_mock.rb
+++ b/spec/helpers/context_mock.rb
@@ -16,6 +16,7 @@ module HighwaySpec
             attr_accessor :run_sh_command
 
             attr_accessor :fastlane_lane_context
+            attr_accessor :sh_error
 
             attr_reader :interface
 
@@ -35,6 +36,9 @@ module HighwaySpec
             def run_sh(command, bundle_exec: false, silent: false, on_error: nil)
                 command = ["bundle exec", command].flatten if bundle_exec && should_use_bundle_exec?
                 @run_sh_command = command
+                if !sh_error.nil? && !on_error.nil?
+                    on_error.call(sh_error)
+                end
             end
         end
     end

--- a/spec/helpers/context_mock.rb
+++ b/spec/helpers/context_mock.rb
@@ -32,7 +32,7 @@ module HighwaySpec
             def assert_gem_available!(name)
             end
 
-            def run_sh(command, bundle_exec: false, silent: false, on_error: nil)
+            def run_sh(command, bundle_exec: false, silent: false, rescue_error: nil)
                 command = ["bundle exec", command].flatten if bundle_exec && should_use_bundle_exec?
                 @run_sh_command = command
             end

--- a/spec/highway/steps/library/xcode_test_spec.rb
+++ b/spec/highway/steps/library/xcode_test_spec.rb
@@ -35,4 +35,37 @@ describe Highway::Steps::Library::XcodeTestStep do
         Highway::Steps::Library::XcodeTestStep.run(parameters: parameters, context: @context, report: @report)
         expect(@context.run_action_name).to eq("run_tests")
     end
+
+    it "Checks using fastlane_params" do
+        fastlane_params = {:extra_param1 => "fixture", :extra_param2 => 2}
+        parameters = {
+            "project" => { :tag => :project, :value => "Project.xcworkspace" },
+            "scheme" => "Release",
+            "flags" => [],
+            "clean" => true,
+            "settings" => {},
+            "fastlane_params" => fastlane_params
+        }
+
+        Highway::Steps::Library::XcodeTestStep.run(parameters: parameters, context: @context, report: @report)
+        expect(@context.run_action_name).to eq("run_tests")
+        expect(@context.run_action_options).to include(fastlane_params)
+    end 
+
+    it "Checks fastlane_params not overriding step params" do
+        fastlane_params = {:scheme => "fixture", :extra_param2 => 2}
+        parameters = {
+            "project" => { :tag => :project, :value => "Project.xcworkspace" },
+            "scheme" => "Release",
+            "flags" => [],
+            "clean" => true,
+            "settings" => {},
+            "fastlane_params" => fastlane_params
+        }
+
+        Highway::Steps::Library::XcodeTestStep.run(parameters: parameters, context: @context, report: @report)
+        expect(@context.run_action_name).to eq("run_tests")
+        expect(@context.run_action_options[:scheme]).to eq("Release")
+        expect(@context.run_action_options[:extra_param2]).to eq(2)
+    end 
 end

--- a/spec/highway/steps/library/xcode_test_spec.rb
+++ b/spec/highway/steps/library/xcode_test_spec.rb
@@ -68,4 +68,21 @@ describe Highway::Steps::Library::XcodeTestStep do
         expect(@context.run_action_options[:scheme]).to eq("Release")
         expect(@context.run_action_options[:extra_param2]).to eq(2)
     end 
+
+    it "Checks if proper error is returned when sh fails" do
+        parameters = {
+            "project" => { :tag => :project, :value => "Project.xcworkspace" },
+            "scheme" => "Release",
+            "flags" => [],
+            "clean" => true,
+            "settings" => {},
+        }
+        error = "Fixture error"
+        @context.sh_error = error
+        begin 
+            Highway::Steps::Library::XcodeTestStep.run(parameters: parameters, context: @context, report: @report)
+        rescue RuntimeError => found_error
+            expect(found_error.message).to eq(error)
+        end    
+    end 
 end


### PR DESCRIPTION
## AS IS
Shell errors when executing `xcode_test` step are not propagated which results with harder debugging of the issues.
When error occurs error log looks like follows:
```
ERROR [2023-01-12 08:52:31.96]: Shell command exited with exit status 2 instead of 0.
ERROR [2023-01-12 08:52:31.96]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/gems/fastlane-2.211.0/fastlane_core/lib/fastlane_core/ui/interface.rb:153:in `shell_error!'
ERROR [2023-01-12 08:52:31.96]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/gems/fastlane-2.211.0/fastlane_core/lib/fastlane_core/ui/ui.rb:17:in `method_missing'
ERROR [2023-01-12 08:52:31.96]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/gems/fastlane-2.211.0/fastlane/lib/fastlane/helper/sh_helper.rb:80:in `sh_control_output'
ERROR [2023-01-12 08:52:31.96]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/gems/fastlane-2.211.0/fastlane/lib/fastlane/helper/sh_helper.rb:12:in `sh'
ERROR [2023-01-12 08:52:31.96]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/gems/highway-1.0.7/lib/highway/runtime/context.rb:205:in `run_sh'
ERROR [2023-01-12 08:52:31.96]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/gems/highway-1.0.7/lib/highway/steps/library/xcode_test.rb:191:in `block in run'
ERROR [2023-01-12 08:52:31.96]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/gems/highway-1.0.7/lib/highway/runtime/context.rb:73:in `with_modified_env'
ERROR [2023-01-12 08:52:31.96]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/gems/highway-1.0.7/lib/highway/steps/library/xcode_test.rb:190:in `run'
ERROR [2023-01-12 08:52:31.96]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/gems/highway-1.0.7/lib/highway/runtime/runner.rb:140:in `run_invocation'
ERROR [2023-01-12 08:52:31.96]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/gems/highway-1.0.7/lib/highway/runtime/runner.rb:98:in `block in run_invocations'
ERROR [2023-01-12 08:52:31.96]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/gems/highway-1.0.7/lib/highway/runtime/runner.rb:97:in `each'
ERROR [2023-01-12 08:52:31.96]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/gems/highway-1.0.7/lib/highway/runtime/runner.rb:97:in `run_invocations'
ERROR [2023-01-12 08:52:31.96]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/gems/highway-1.0.7/lib/highway/runtime/runner.rb:58:in `run'
ERROR [2023-01-12 08:52:31.96]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/gems/highway-1.0.7/lib/highway/main.rb:88:in `block in run'
ERROR [2023-01-12 08:52:31.96]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/gems/highway-1.0.7/lib/highway/main.rb:46:in `chdir'
ERROR [2023-01-12 08:52:31.96]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/gems/highway-1.0.7/lib/highway/main.rb:46:in `run'
```

## TO BE
Propagate errors from executing sh commands so it will be easier to debug the issues. Example output should look like follows:
```
ERROR [2023-01-12 08:04:34.91]: Shell command exited with exit status 2 instead of 0.
ERROR [2023-01-12 08:04:34.91]: RuntimeError: sh: -c: line 0: syntax error near unexpected token `('
ERROR [2023-01-12 08:04:34.91]: sh: -c: line 0: `bundle exec cat /Users/vagrant/git/iosApp/fastlane/highway/2-xcode_test-raw.log | xcpretty --formatter Your RubyGems version (3.0.3.1) has a bug that prevents `required_ruby_version` from working for Bundler. Any scripts that use `gem install bundler` will break as soon as Bundler drops support for your Ruby version. Please upgrade RubyGems to avoid future breakage and silence this warning by running `gem update --system 3.2.3`'
ERROR [2023-01-12 08:04:34.91]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/bundler/gems/highway-62017bb24096/lib/highway/steps/library/xcode_test.rb:270:in `run'
ERROR [2023-01-12 08:04:34.91]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/bundler/gems/highway-62017bb24096/lib/highway/runtime/runner.rb:140:in `run_invocation'
ERROR [2023-01-12 08:04:34.91]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/bundler/gems/highway-62017bb24096/lib/highway/runtime/runner.rb:98:in `block in run_invocations'
ERROR [2023-01-12 08:04:34.91]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/bundler/gems/highway-62017bb24096/lib/highway/runtime/runner.rb:97:in `each'
ERROR [2023-01-12 08:04:34.91]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/bundler/gems/highway-62017bb24096/lib/highway/runtime/runner.rb:97:in `run_invocations'
ERROR [2023-01-12 08:04:34.91]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/bundler/gems/highway-62017bb24096/lib/highway/runtime/runner.rb:58:in `run'
ERROR [2023-01-12 08:04:34.91]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/bundler/gems/highway-62017bb24096/lib/highway/main.rb:88:in `block in run'
ERROR [2023-01-12 08:04:34.91]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/bundler/gems/highway-62017bb24096/lib/highway/main.rb:46:in `chdir'
ERROR [2023-01-12 08:04:34.91]: /Users/vagrant/git/iosApp/bundler/gems/ruby/2.6.0/bundler/gems/highway-62017bb24096/lib/highway/main.rb:46:in `run'
```